### PR TITLE
Added option in 'test load' for outputing in csv format

### DIFF
--- a/lib/format_load_csv.js
+++ b/lib/format_load_csv.js
@@ -1,0 +1,54 @@
+var gauss = require('gauss');
+var csv = require('fast-csv');
+
+module.exports = function(opts, peerFactory, showHeaders) {
+  var connectEvents = peerFactory.events.filter(function(ev) { return ev.event === 'connect' });  
+  var disconnectEvents = peerFactory.events.filter(function(ev) { return ev.event === 'disconnect' });
+
+  var connectTimeV = new gauss.Vector(connectEvents.map(function(e) {
+    return e.timeToConnect; 
+  }));
+  
+  var peerEvents = {};
+  connectEvents.forEach(function(e) {
+    if (!peerEvents[e.name]) {
+      peerEvents[e.name] = [];
+    }
+    peerEvents[e.name].push(e);
+  });
+
+  disconnectEvents.forEach(function(e) {
+    if (!peerEvents[e.name]) {
+      peerEvents[e.name] = [];
+    }
+    peerEvents[e.name].push(e);
+  });
+
+
+  var connectsPerPeerV = new gauss.Vector(Object.keys(peerEvents).map(function(name) {
+    return peerEvents[name].length;
+  }));
+
+  var csvStream = csv.createWriteStream({ headers: showHeaders });
+  csvStream.pipe(process.stdout);
+
+  csvStream.write({ 
+    url: opts.url,
+    sensors: opts.sensors,
+    actuators: opts.actuators,
+    instances: opts.instances,
+    ConnectTimeMin: connectTimeV.min(),
+    ConnectTimeMax: connectTimeV.max(),
+    ConnectTimeMedian: connectTimeV.median(),
+    ConnectTimeMean: connectTimeV.mean(),
+    ConnectTimeStdev: connectTimeV.stdev(),
+    
+    ConnectAttemptsMin: connectsPerPeerV.min(),
+    ConnectAttemptsMax: connectsPerPeerV.max(),
+    ConnectAttemptsMedian: connectsPerPeerV.median(),
+    ConnectAttemptsMean: connectsPerPeerV.mean(),
+    ConnectAttemptsStdev: connectsPerPeerV.stdev()
+  });
+  csvStream.end();
+  console.log();
+}

--- a/voltron-test-load
+++ b/voltron-test-load
@@ -6,6 +6,7 @@ var progress = require('progress');
 var table = require('cli-table');
 var PeerFactory = require('./lib/peer_factory');
 var path = require('path');
+var csvProcess = require('./lib/format_load_csv');
 
 program
   .option('-i --instances <number>', 'Number of instances to start. Default 10.', parseInt)
@@ -15,6 +16,8 @@ program
   .option('-s, --silent', 'Silence output')
   .option('--spec <path>', 'Specification file path.')
   .option('-t --time <time>', 'Time in seconds to run test for. Defaults to 60.')
+  .option('--csv', 'Format output as csv.')
+  .option('--csv-headers', 'Add headers to csv output.')
   .parse(process.argv);
 
 var url = program.args[0];
@@ -63,9 +66,6 @@ var opts = {
   instances: instances  
 };
 
-console.log('Beginning process spawn.');
-
-var bar = new progress(':bar', { total: instances });
 
 if(!url) {
   return new Error('Server URL must be provided');
@@ -73,13 +73,18 @@ if(!url) {
 
 var peerFactory = new PeerFactory(opts);
 
-peerFactory.on('connect', function() {
-  bar.tick();
-  if(bar.complete) {
-   console.log('Completed process spawn. Waiting for connections...');  
-  }
-});
- 
+if (!program.csv) {
+  console.log('Beginning process spawn.');
+
+  var bar = new progress(':bar', { total: instances });
+  peerFactory.on('connect', function() {
+    bar.tick();
+    if(bar.complete) {
+      console.log('Completed process spawn. Waiting for connections...');  
+    }
+  });
+}
+
 peerFactory.start();
 
 function processData(data) {
@@ -116,7 +121,12 @@ var time = duration * 1000;
 if(time !== 0) {
   setTimeout(function() {
     peerFactory.kill();
-    processData(peerFactory.events);
+    
+    if (!program.csv) {     
+      processData(peerFactory.events);
+    } else {
+      csvProcess(opts, peerFactory, program.csvHeaders);
+    }
   }, time);
 }
 


### PR DESCRIPTION
`voltron test load` adds command line options for `--csv` and `--csv-headers` which outputs the connection metrics in csv format, you can include headers for what the metrics are with the headers flag.
